### PR TITLE
Update amdTemplateEngine.js

### DIFF
--- a/src/amdTemplateEngine.js
+++ b/src/amdTemplateEngine.js
@@ -20,7 +20,10 @@
     ko.templateSources.requireTemplate.prototype.text = function(value) {
         //when the template is retrieved, check if we need to load it
         if (!this.requested && this.key) {
-            require([engine.defaultRequireTextPluginName + "!" + addTrailingSlash(engine.defaultPath) + this.key + engine.defaultSuffix], function(templateContent) {
+            var filename = this.key + engine.defaultSuffix;
+            if(filename.charAt(0) != '/') filename = addTrailingSlash(engine.defaultPath) + filename;
+            
+            require([engine.defaultRequireTextPluginName + "!" + filename], function(templateContent) {
                 this.retrieved = true;
                 this.template(templateContent);
             }.bind(this));


### PR DESCRIPTION
Allows templates to be started with "/" which will not use relative paths. I did not rebuild this project so that part will have to be done still.
