### PR TITLE
Let afterRender take function name arguement

### DIFF
--- a/src/amdBindings.js
+++ b/src/amdBindings.js
@@ -19,7 +19,11 @@ ko.bindingHandlers.module = {
 
             if (options && typeof options.afterRender === "function") {
                 options.afterRender.apply(this, arguments);
+            }else if (options && typeof options.afterRender === "string") {
+                options.afterRender = arguments[1][options.afterRender];
+                options.afterRender.apply(this, arguments);
             }
+            
         };
 
         //if this is not an anonymous template, then build a function to properly return the template name


### PR DESCRIPTION
Allows user to specify the function within the respective module.js that should fire after render.
